### PR TITLE
Avoid block copy operations in scrypt's SMix step to improve performance

### DIFF
--- a/packages/scrypt/scrypt.ts
+++ b/packages/scrypt/scrypt.ts
@@ -82,7 +82,6 @@ export class Scrypt {
     }
 
     clean() {
-        wipe(this._XY);
         wipe(this._V);
     }
 }

--- a/packages/scrypt/scrypt.ts
+++ b/packages/scrypt/scrypt.ts
@@ -114,9 +114,8 @@ function smix(B: Uint8Array, r: number, N: number, V: Int32Array, XY: Int32Array
     for (let i = 0; i < 32 * r; i++) {
         V[i] = readUint32LE(B, i * 4);
     }
-    for (let i = 0; i < N; i += 2) {
+    for (let i = 0; i < N; i++) {
         blockMix(tmp, V, i * (32 * r), (i + 1) * (32 * r), r);
-        blockMix(tmp, V, (i + 1) * (32 * r), (i + 2) * (32 * r), r);
     }
     for (let i = 0; i < N; i += 2) {
         let j = integerify(XY, xi, r) & (N - 1);
@@ -190,9 +189,8 @@ function smixAsync(B: Uint8Array, r: number, N: number, V: Int32Array, XY: Int32
 
     return Promise.resolve(initialStep)
         .then(step => splitCalc(0, N, step, (i: number, end: number): number => {
-            for (; i < end; i += 2) {
+            for (; i < end; i++) {
                 blockMix(tmp, V, i * (32 * r), (i + 1) * (32 * r), r);
-                blockMix(tmp, V, (i + 1) * (32 * r), (i + 2) * (32 * r), r);
             }
             return i;
         }))


### PR DESCRIPTION
Function `smix()` in the scrypt implementation currently does something like that:

* Initialize X
* Copy X to V[0]
* Mix X to Y
* Copy Y to V[1]
* Mix Y to X
* Copy X to V[2]
* ...

If you look closely, the copy operations are unnecessary. Instead, one can do the following:

* Initialize V[0]
* Mix V[0] to V[1]
* Mix V[1] to V[2]
* ...

Only the very last mix operation is slightly problematic because there is no space in V for the result any more and it needs to go into X. This issue can be avoided by allocating X and Y at the end of the V array. That's what I have done now, improves performance by around 10% for me (in both Firefox and Chrome).