### PR TITLE
Change UTF-8 decoder to avoid maximum stack size being exceeded

### DIFF
--- a/packages/utf8/utf8.ts
+++ b/packages/utf8/utf8.ts
@@ -73,7 +73,7 @@ export function encodedLength(s: string): number {
  * Throws if encoding is invalid.
  */
 export function decode(arr: Uint8Array): string {
-    const chars: number[] = [];
+    const chars: string[] = [];
     for (let i = 0; i < arr.length; i++) {
         let b = arr[i];
 
@@ -129,12 +129,12 @@ export function decode(arr: Uint8Array): string {
                     throw new Error(INVALID_UTF8);
                 }
                 b -= 0x10000;
-                chars.push(0xd800 | (b >> 10));
+                chars.push(String.fromCharCode(0xd800 | (b >> 10)));
                 b = 0xdc00 | (b & 0x3ff);
             }
         }
 
-        chars.push(b);
+        chars.push(String.fromCharCode(b));
     }
-    return String.fromCharCode.apply(null, chars);
+    return chars.join("");
 }


### PR DESCRIPTION
While using the UTF-8 library today, I came across a scenario where the number of bytes I was trying to convert back into UTF-8 was failing with a "Maximum call stack size exceeded". I did some research and discovered that this was happening because of the `String.fromCharCode.apply(null, chars)` call as Chrome only supports something like ~125K parameters, and so doing an `apply` with an array that's larger than that causes the max stack size to be reached.

There's likely a myriad of different ways to fix this, but I've come up with a proposal below which just generates the array of UTF-8 strings as it goes, then just does an `Array.join` to concat them all together. I couldn't quite figure out how to run the benchmarks, but I did some pretty quick hasty testing and I didn't see much of a runtime difference when converting a 32K string into bytes and back to UTF-8.

Let me know if you'd like me to poke at some other things. I haven't messed with lerna much so I wasn't sure exactly of the process for running the unit tests either.  