### PR TITLE
feat(aes-kw): add aes key wrapping implementation

### DIFF
--- a/packages/aes-kw/LICENSE
+++ b/packages/aes-kw/LICENSE
@@ -1,0 +1,76 @@
+This software is licensed under the MIT license:
+
+Copyright (C) 2020 Tobias Looker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This software includes code derived from other projects:
+
+AES
+https://golang.org/src/crypto/aes/
+
+Optimised ANSI C code for the Rijndael cipher (now AES)
+
+@author Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
+@author Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>
+@author Paulo Barreto <paulo.barreto@terra.com.br>
+
+This code is hereby placed in the public domain.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ''AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/aes-kw/aes-kw.test.ts
+++ b/packages/aes-kw/aes-kw.test.ts
@@ -1,0 +1,87 @@
+// Copyright (C) 2020 Tobias Looker
+// MIT License. See LICENSE file for details.
+
+import { AESKW } from "./aes-kw";
+import { encode, decode } from "@stablelib/hex";
+
+// Test vectors sourced from RFC 3394
+// @see https://tools.ietf.org/html/rfc3394
+const testVectors = [
+    {
+        Description: "128 bits of Key Data with a 128-bit KEK",
+        KEK: "000102030405060708090A0B0C0D0E0F",
+        KeyData: "00112233445566778899AABBCCDDEEFF",
+        WrappedKey: "1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5"
+    },
+    {
+        Description: "128 bits of Key Data with a 192-bit KEK",
+        KEK: "000102030405060708090A0B0C0D0E0F1011121314151617",
+        KeyData: "00112233445566778899AABBCCDDEEFF",
+        WrappedKey: "96778B25AE6CA435F92B5B97C050AED2468AB8A17AD84E5D"
+    },
+    {
+        Description: "128 bits of Key Data with a 256-bit KEK",
+        KEK: "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
+        KeyData: "00112233445566778899AABBCCDDEEFF",
+        WrappedKey: "64E8C3F9CE0F5BA263E9777905818A2A93C8191E7D6E8AE7"
+    },
+    {
+        Description: "192 bits of Key Data with a 192-bit KEK",
+        KEK: "000102030405060708090A0B0C0D0E0F1011121314151617",
+        KeyData: "00112233445566778899AABBCCDDEEFF0001020304050607",
+        WrappedKey: "031D33264E15D33268F24EC260743EDCE1C6C7DDEE725A936BA814915C6762D2"
+    },
+    {
+        Description: "192 bits of Key Data with a 256-bit KEK",
+        KEK: "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
+        KeyData: "00112233445566778899AABBCCDDEEFF0001020304050607",
+        WrappedKey: "A8F9BC1612C68B3FF6E6F4FBE30E71E4769C8B80A32CB8958CD5D17D6B254DA1"
+    },
+    {
+        Description: "256 bits of Key Data with a 256-bit KEK",
+        KEK: "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
+        KeyData: "00112233445566778899AABBCCDDEEFF000102030405060708090A0B0C0D0E0F",
+        WrappedKey: "28C9F404C4B810F4CBCCB35CFB87F8263F5786E2D80ED326CBC7F0E71A99F43BFB988B9B7A02DD21"
+    }
+];
+
+const keyEncryptionKey = "000102030405060708090A0B0C0D0E0F";
+const tooShortKeyData = "001122334455";
+
+describe("wrapKey", () => {
+    testVectors.forEach(v => {
+        it(`should wrap ${v.Description}`, () => {
+            const aeskw = new AESKW(decode(v.KEK));
+            const wrappedKey = aeskw.wrapKey(decode(v.KeyData));
+            expect(encode(wrappedKey)).toBe(v.WrappedKey);
+        });
+    });
+
+    it("should throw an error wrapping keyData that does not have sufficient length", () => {
+        const aeskw = new AESKW(decode(keyEncryptionKey)); 
+        expect(() => aeskw.wrapKey(decode(tooShortKeyData)))
+                          .toThrowError("aeskw: key data insufficient length must be a minimum of 128 bits or 16 bytes");
+    });
+});
+
+describe("unWrapKey", () => {
+    testVectors.forEach(v => {
+        it(`should unWrap ${v.Description}`, () => {
+            const aeskw = new AESKW(decode(v.KEK));
+            const keyData = aeskw.unwrapKey(decode(v.WrappedKey));
+            expect(encode(keyData)).toBe(v.KeyData);
+        });
+    });
+
+    it("should throw an error un-wrapping a wrapped key that does not have sufficient length", () => {
+        const aeskw = new AESKW(decode(keyEncryptionKey)); 
+        expect(() => aeskw.unwrapKey(decode(tooShortKeyData)))
+                          .toThrowError("aeskw: key data insufficient length must be a minimum of 128 bits or 16 bytes");
+    });
+    
+    it("should throw an error unWrapping a wrapped key that does not contain the default IV", () => {
+        const aeskw = new AESKW(decode(keyEncryptionKey)); 
+        expect(() => aeskw.unwrapKey(decode("E2EF32C0BBC36B6D236C2FD28E68FCDA8E24204C59F98754889D1ED24364A4D130AF535D350B9243")))
+                          .toThrowError("aeskw: unwrapped data does not contain the default iv");
+    });
+});

--- a/packages/aes-kw/aes-kw.ts
+++ b/packages/aes-kw/aes-kw.ts
@@ -1,0 +1,138 @@
+// Copyright (C) 2020 Tobias Looker
+// MIT License. See LICENSE file for details.
+
+import { AES } from "@stablelib/aes";
+import { writeUint64BE } from "@stablelib/binary";
+import { BlockCipher } from "@stablelib/blockcipher";
+import { wipe } from "@stablelib/wipe";
+import { compare } from "@stablelib/constant-time";
+
+/**
+ * An implementation of the Advance Encryption Standard Key Wrapping Algorithm (AES-KW)
+ * originally designed by NIST and formalized in RFC 3394
+ * @see https://tools.ietf.org/html/rfc3394
+ * @see http://csrc.nist.gov/encryption/kms/key-wrap.pdf
+ */
+export class AESKW {
+    private _inputBuffer: Uint8Array;
+    private _outputBuffer: Uint8Array;
+    private _cipher: BlockCipher;
+    private _iv: Uint8Array;
+
+    /**
+     * Constructs a class capable of advance encryption standard key wrapping
+     * @param key: The key encryption key used to wrap and un-wrap
+     */
+    constructor(key: Uint8Array) {
+        // Set the cipher to AES
+        this._cipher = new AES(key);
+
+        // Set the initial value to that documented in section 2.2.3.1
+        // @see https://tools.ietf.org/html/rfc3394#section-2.2.3.1
+        this._iv = new Uint8Array([0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6]);
+
+        // Initialize the input and output buffers
+        this._inputBuffer = new Uint8Array(this._cipher.blockSize);
+        this._outputBuffer = new Uint8Array(this._cipher.blockSize);
+    }
+    
+    /**
+     * Cleans the buffers and underlying memory associated to the cipher
+     */
+    clean(): this {
+        wipe(this._inputBuffer);
+        wipe(this._inputBuffer);
+        this._cipher.clean();
+        return this;
+    }
+
+    /**
+     * Wraps supplied key data with the key encryption key supplied in the
+     * constructor
+     * @param keyData: The key data to wrap with the key encryption key
+     */
+    wrapKey(keyData: Uint8Array): Uint8Array {
+        // Floor divide the length of the key data to determine 
+        // how many 64 bit data blocks it contains
+        const N = (keyData.length - (keyData.length % 8)) / 8;
+
+        // The keyData must be at minimum 128 bit (16 bytes) in length
+        if (N <= 1) {
+            throw new Error("aeskw: key data insufficient length must be a minimum of 128 bits or 16 bytes");
+        }
+
+        // Set A to the initial value
+        let A = this._iv;
+        // Initialize the length of the wrapped key, size always equals N+1
+        const wrappedKey = new Uint8Array(8*(N+1));
+        // Set the plain text into the wrapped key array offset by one
+        // 64 bit data block
+        wrappedKey.set(keyData, 8);
+
+        for (let j = 0; j < 6; j++) {
+            for (let i = 1; i <= N; i++) {
+                this._inputBuffer.set(A);
+                this._inputBuffer.set(wrappedKey.subarray(i*8,(i+1)*8),8);
+                this._cipher.encryptBlock(this._inputBuffer, this._outputBuffer);
+                A = writeUint64BE(i + j*N);
+                this.xor(A, this._outputBuffer.subarray(0,8));
+                wrappedKey.set(this._outputBuffer.subarray(8,16), i*8);
+            }
+        }
+
+        wrappedKey.set(A);
+        return wrappedKey;
+    }
+
+    /**
+     * Un-wraps a wrapped key using the key encryption key supplied in the
+     * constructor
+     * @param wrappedKey: The wrapped key to un-wrap with the key encryption key
+     */
+    unwrapKey(wrappedKey: Uint8Array): Uint8Array {
+        // Floor divide the length of the unwrapped key to determine 
+        // how many 64 bit data blocks it contains, N represents the number
+        // of 64 bit data blocks of the plain text which is always one less
+        // than the cipher text
+        const N = ((wrappedKey.length - (wrappedKey.length % 8)) / 8) - 1;
+        
+        // The keyData must be at minimum 128 bit (16 bytes) in length
+        if (N <= 1) {
+            throw new Error("aeskw: key data insufficient length must be a minimum of 128 bits or 16 bytes");
+        }
+
+        // Set A to the first 64 bit data block of the wrapped key
+        let A = wrappedKey.subarray(0,8);
+        // Initialize the length of the key data, size always equals N
+        const keyData = new Uint8Array(8*(N));
+
+        for (let j = 5; j >= 0; j--) {
+            for (let i = N; i >= 1; i--) {
+                this.xor(A, writeUint64BE(i + j*N));
+                this._inputBuffer.set(A);
+                this._inputBuffer.set(wrappedKey.subarray((i)*8,(i+1)*8),8);
+                this._cipher.decryptBlock(this._inputBuffer, this._outputBuffer);
+                A.set(this._outputBuffer.subarray(0,8));
+                wrappedKey.set(this._outputBuffer.subarray(8,16), i*8);
+            }
+        }
+
+        // Integrity check, the A component of the un-wrapped key buffer should
+        // equal the default initial value
+        if (compare(A, this._iv) == 0) {
+            throw new Error("aeskw: unwrapped data does not contain the default iv");
+        }
+
+        keyData.set(wrappedKey.subarray(8))
+        return keyData;
+    }
+
+    /**
+     * Internal method for bitwise XOR of two Uint8Arrays
+     */
+    private xor(a: Uint8Array, b: Uint8Array) {
+        for (let i = 0; i < b.length; i++) {
+            a[i] ^= b[i];
+        }
+    }
+}

--- a/packages/aes-kw/aes-kw.ts
+++ b/packages/aes-kw/aes-kw.ts
@@ -105,15 +105,16 @@ export class AESKW {
         let A = wrappedKey.subarray(0,8);
         // Initialize the length of the key data, size always equals N
         const keyData = new Uint8Array(8*(N));
+        const encryptedKeyData = new Uint8Array(wrappedKey);
 
         for (let j = 5; j >= 0; j--) {
             for (let i = N; i >= 1; i--) {
                 this.xor(A, writeUint64BE(i + j*N));
                 this._inputBuffer.set(A);
-                this._inputBuffer.set(wrappedKey.subarray((i)*8,(i+1)*8),8);
+                this._inputBuffer.set(encryptedKeyData.subarray((i)*8,(i+1)*8),8);
                 this._cipher.decryptBlock(this._inputBuffer, this._outputBuffer);
                 A.set(this._outputBuffer.subarray(0,8));
-                wrappedKey.set(this._outputBuffer.subarray(8,16), i*8);
+                encryptedKeyData.set(this._outputBuffer.subarray(8,16), i*8);
             }
         }
 
@@ -123,12 +124,12 @@ export class AESKW {
             throw new Error("aeskw: unwrapped data does not contain the default iv");
         }
 
-        keyData.set(wrappedKey.subarray(8))
+        keyData.set(encryptedKeyData.subarray(8))
         return keyData;
     }
 
     /**
-     * Internal method for bitwise XOR of two Uint8Arrays
+     * Internal method for bitwise XOR of b into a
      */
     private xor(a: Uint8Array, b: Uint8Array) {
         for (let i = 0; i < b.length; i++) {

--- a/packages/aes-kw/package.json
+++ b/packages/aes-kw/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@stablelib/aes-kw",
+  "version": "1.0.0",
+  "description": "AES KW (Advanced Encryption Standard Key Wrapping)",
+  "main": "./lib/aes-kw.js",
+  "typings": "./lib/aes-kw.d.ts",
+  "contributors": [
+    {
+      "name": "Dmitry Chestnykh"
+    },
+    {
+      "name": "Tobias Looker"
+    }
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "jasmine JASMINE_CONFIG_PATH=../../configs/jasmine.json"
+  },
+  "dependencies": {
+    "@stablelib/aes": "^1.0.0",
+    "@stablelib/binary": "^1.0.0",
+    "@stablelib/blockcipher": "^1.0.0",
+    "@stablelib/constant-time": "^1.0.0",
+    "@stablelib/wipe": "^1.0.0"
+  },
+  "devDependencies": {
+    "@stablelib/hex": "^1.0.0"
+  }
+}

--- a/packages/aes-kw/tsconfig.json
+++ b/packages/aes-kw/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+      "target": "es5",
+      "module": "commonjs",
+      "strict": true,
+      "noUnusedParameters": true,
+      "noImplicitReturns": true,
+      "noUnusedLocals": true,
+      "removeComments": false,
+      "preserveConstEnums": true,
+      "moduleResolution": "node",
+      "newLine": "LF",
+      "sourceMap": true,
+      "declaration": true,
+      "outDir": "lib",
+      "lib": [
+          "es5",
+          "es2015.promise",
+          "dom",
+          "scripthost"
+      ]
+  },
+  "exclude": [
+      "node_modules",
+      "lib"
+  ]
+}


### PR DESCRIPTION
This PR adds an implementation of AES key wrapping as documented by [RFC3394](https://tools.ietf.org/html/rfc3394).