### PR TITLE
fix(random): hint bundler browser targets, webpack5

### DIFF
--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -25,6 +25,9 @@
     "@stablelib/benchmark": "^1.0.0",
     "@stablelib/hex": "^1.0.0"
   },
+  "browser": {
+    "crypto": false
+  },
   "react-native": {
     "crypto": false
   }


### PR DESCRIPTION
webpack5 no longer by default polyfills node libs like crypto, so by default build/bundle fails when consuming lib
https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed

noticed already split by node/browser for runtime, this just hints to bundlers (webpack5) for browser targets that its safe to not include crypto and wont complain at build

probably helpful having similar changes in other packages here as well, but currently only needed random for now