### PR TITLE
TypeScript 4.7.2 build fix

### DIFF
--- a/configs/tsconfig.json
+++ b/configs/tsconfig.json
@@ -12,15 +12,10 @@
         "newLine": "LF",
         "sourceMap": true,
         "declaration": true,
-        "outDir": "lib",
         "lib": [
             "es2015",
             "dom",
             "scripthost"
         ]
     },
-    "exclude": [
-        "node_modules",
-        "lib"
-    ]
 }

--- a/packages/aead/tsconfig.json
+++ b/packages/aead/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/aes-kw/tsconfig.json
+++ b/packages/aes-kw/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/aes/tsconfig.json
+++ b/packages/aes/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/base64/tsconfig.json
+++ b/packages/base64/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/binary/tsconfig.json
+++ b/packages/binary/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/blake2b/tsconfig.json
+++ b/packages/blake2b/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/blake2s/tsconfig.json
+++ b/packages/blake2s/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/blake2xs/tsconfig.json
+++ b/packages/blake2xs/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/blockcipher/tsconfig.json
+++ b/packages/blockcipher/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/bytereader/tsconfig.json
+++ b/packages/bytereader/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/bytes/tsconfig.json
+++ b/packages/bytes/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/bytewriter/tsconfig.json
+++ b/packages/bytewriter/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/cbor/tsconfig.json
+++ b/packages/cbor/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/chacha-drbg/tsconfig.json
+++ b/packages/chacha-drbg/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/chacha/tsconfig.json
+++ b/packages/chacha/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/chacha20poly1305/tsconfig.json
+++ b/packages/chacha20poly1305/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/cmac/tsconfig.json
+++ b/packages/cmac/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/constant-time/tsconfig.json
+++ b/packages/constant-time/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/ctr/tsconfig.json
+++ b/packages/ctr/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/ed25519/tsconfig.json
+++ b/packages/ed25519/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/float/tsconfig.json
+++ b/packages/float/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/gcm/tsconfig.json
+++ b/packages/gcm/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/gf256/tsconfig.json
+++ b/packages/gf256/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/halfsiphash/tsconfig.json
+++ b/packages/halfsiphash/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/hash/tsconfig.json
+++ b/packages/hash/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/hex/tsconfig.json
+++ b/packages/hex/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/hkdf/tsconfig.json
+++ b/packages/hkdf/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/hmac-drbg/tsconfig.json
+++ b/packages/hmac-drbg/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/hmac/tsconfig.json
+++ b/packages/hmac/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/int/tsconfig.json
+++ b/packages/int/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/keyagreement/tsconfig.json
+++ b/packages/keyagreement/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/nacl/tsconfig.json
+++ b/packages/nacl/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/newhope/tsconfig.json
+++ b/packages/newhope/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/pbkdf2/tsconfig.json
+++ b/packages/pbkdf2/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/poly1305/tsconfig.json
+++ b/packages/poly1305/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/random/source/browser.ts
+++ b/packages/random/source/browser.ts
@@ -16,7 +16,7 @@ export class BrowserRandomSource implements RandomSource {
             ? (self.crypto || (self as { msCrypto?: any }).msCrypto) // IE11 has msCrypto
             : null;
 
-        if (browserCrypto && browserCrypto.getRandomValues) {
+        if (browserCrypto && browserCrypto.getRandomValues !== undefined) {
             this._crypto = browserCrypto;
             this.isAvailable = true;
             this.isInstantiated = true;

--- a/packages/random/tsconfig.json
+++ b/packages/random/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/salsa20/tsconfig.json
+++ b/packages/salsa20/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/scrypt/package.json
+++ b/packages/scrypt/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@stablelib/base64": "^1.0.1",
     "@stablelib/benchmark": "^1.0.1",
-    "@stablelib/utf8": "^1.0.1"
+    "@stablelib/utf8": "^1.0.1",
+    "@types/node": "^18.7.6"
   }
 }

--- a/packages/scrypt/tsconfig.json
+++ b/packages/scrypt/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/sha224/tsconfig.json
+++ b/packages/sha224/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/sha256/tsconfig.json
+++ b/packages/sha256/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/sha3/tsconfig.json
+++ b/packages/sha3/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/sha384/tsconfig.json
+++ b/packages/sha384/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/sha512/tsconfig.json
+++ b/packages/sha512/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/sha512_256/tsconfig.json
+++ b/packages/sha512_256/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/siv/tsconfig.json
+++ b/packages/siv/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/snappy/package.json
+++ b/packages/snappy/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@stablelib/benchmark": "^1.0.1",
     "@stablelib/hex": "^1.0.1",
-    "@stablelib/utf8": "^1.0.1"
+    "@stablelib/utf8": "^1.0.1",
+    "@types/node": "^18.7.6"
   }
 }

--- a/packages/snappy/tsconfig.json
+++ b/packages/snappy/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/tss/tsconfig.json
+++ b/packages/tss/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/utf8/tsconfig.json
+++ b/packages/utf8/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/uuid/tsconfig.json
+++ b/packages/uuid/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/wipe/tsconfig.json
+++ b/packages/wipe/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/x25519/tsconfig.json
+++ b/packages/x25519/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/xchacha20/tsconfig.json
+++ b/packages/xchacha20/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/xchacha20poly1305/tsconfig.json
+++ b/packages/xchacha20poly1305/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }

--- a/packages/xsalsa20/tsconfig.json
+++ b/packages/xsalsa20/tsconfig.json
@@ -1,3 +1,10 @@
 {
-    "extends": "../../configs/tsconfig.json"
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+    },
+    "exclude": [
+        "node_modules",
+        "lib"
+    ]
 }


### PR DESCRIPTION
This PR fixes some building issues with latest environments. It covers
* Path resolution in `extend`'ed `tsconfig.json` files
* Missing dependencies
* Fixes for some minor Typescript compile error as the compiler became more strict