### PR TITLE
API Compatibility with base64-js (@stablelib/base64)

### DIFF
--- a/packages/base64/base64.ts
+++ b/packages/base64/base64.ts
@@ -281,3 +281,29 @@ export const maxDecodedLength = (length: number) =>
 
 export const decodedLength = (s: string) =>
     stdCoder.decodedLength(s);
+
+
+// BEGIN API Compatibility with base64-js
+
+/**
+ * Alias for ``decodedLength``, included for ``base64-js`` API compatibility
+ */
+export function byteLength(b64: string): number {
+    return stdCoder.decodedLength(b64);
+}
+
+/**
+ * Alias for ``decode``, included for ``base64-js`` API compatibility
+ */
+export function toByteArray(b64: string): Uint8Array {
+    return stdCoder.decode(b64);
+}
+
+/**
+ * Alias for ``encode``, included for ``base64-js`` API compatibility
+ */
+export function fromByteArray(uint8: Uint8Array): string {
+    return stdCoder.encode(uint8);
+}
+
+// END API Compatibility with base64-js

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablelib/base64",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Base64 encoding and decoding",
   "main": "./lib/base64.js",
   "typings": "./lib/base64.d.ts",


### PR DESCRIPTION
This expands the exports of ``@stablelib/base64`` to provide identical functionality to the ``base64-js`` package. This would allow developers to produce smaller bundles by using only 1 base64 impl when ``base64-js`` would otherwise be required by other packages, notably ``buffer``.
```json
  "dependencies": {
    "@stablelib/base64": "^1.0.2",
    "buffer": "^6.0.3"
  },
  "overrides": {
    "base64-js": "npm:@stablelib/base64@1.0.2"
  }
```