### PR TITLE
fix: Add file extension to relative imports for better ES module compatibility

### DIFF
--- a/packages/keyagreement/concat.ts
+++ b/packages/keyagreement/concat.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 Dmitry Chestnykh
 // MIT License. See LICENSE file for details.
 
-import type { KeyAgreement } from "./keyagreement";
+import type { KeyAgreement } from "./keyagreement.js";
 import { concat } from "@stablelib/bytes";
 
 /**

--- a/packages/nacl/box.ts
+++ b/packages/nacl/box.ts
@@ -3,7 +3,7 @@
 
 import { scalarMult } from "@stablelib/x25519";
 import { hsalsa } from "@stablelib/xsalsa20";
-import { secretBox, openSecretBox } from "./secretbox";
+import { secretBox, openSecretBox } from "./secretbox.js";
 import { wipe } from "@stablelib/wipe";
 
 export { generateKeyPair } from "@stablelib/x25519";

--- a/packages/nacl/nacl.ts
+++ b/packages/nacl/nacl.ts
@@ -5,5 +5,5 @@
  * Package nacl implements NaCl (Networking and Cryptography library) cryptography.
  */
 
-export * from "./box";
-export * from "./secretbox";
+export * from "./box.js";
+export * from "./secretbox.js";

--- a/packages/newhope/newhope.ts
+++ b/packages/newhope/newhope.ts
@@ -28,8 +28,8 @@
 
 import type { RandomSource } from "@stablelib/random";
 import { SHAKE128, SHA3256 } from "@stablelib/sha3";
-import type { SeedExpander} from "./custom";
-import { CustomNewHope } from "./custom";
+import type { SeedExpander} from "./custom.js";
+import { CustomNewHope } from "./custom.js";
 
 export {
     PUBLIC_SEED_LENGTH,

--- a/packages/random/random.ts
+++ b/packages/random/random.ts
@@ -6,12 +6,12 @@
  * cryptographically secure random byte generator.
  */
 
-import type { RandomSource } from "./source";
-import { SystemRandomSource } from "./source/system";
+import type { RandomSource } from "./source/index.js";
+import { SystemRandomSource } from "./source/system.js";
 import { readUint32LE } from "@stablelib/binary";
 import { wipe } from "@stablelib/wipe";
 
-export { RandomSource } from "./source";
+export { RandomSource } from "./source/index.js";
 
 export const defaultRandomSource = new SystemRandomSource();
 

--- a/packages/random/source/system.ts
+++ b/packages/random/source/system.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2024 Dmitry Chestnykh
 // MIT License. See LICENSE file for details.
 
-import { RandomSource } from "./";
+import type { RandomSource } from "./index.js";
 
 const QUOTA = 65536;
 

--- a/packages/snappy/snappy.ts
+++ b/packages/snappy/snappy.ts
@@ -11,5 +11,5 @@
  * Package snappy implements Snappy compression and decompression.
  */
 
-export * from "./compress";
-export * from "./decompress";
+export * from "./compress.js";
+export * from "./decompress.js";

--- a/packages/x25519-session/keyagreement.ts
+++ b/packages/x25519-session/keyagreement.ts
@@ -13,7 +13,7 @@ import { PUBLIC_KEY_LENGTH,
     generateKeyPairFromSeed,
     sharedKey } from "@stablelib/x25519";
 import type { SessionKeys} from "./x25519-session";
-import { clientSessionKeysFromSharedKey, serverSessionKeysFromSharedKey } from "./x25519-session";
+import { clientSessionKeysFromSharedKey, serverSessionKeysFromSharedKey } from "./x25519-session.js";
 
 /** Constants for key agreement */
 export const OFFER_MESSAGE_LENGTH = PUBLIC_KEY_LENGTH;

--- a/packages/x25519-session/x25519-session.ts
+++ b/packages/x25519-session/x25519-session.ts
@@ -9,7 +9,7 @@ import { BLAKE2b } from "@stablelib/blake2b";
 import type { Hash } from "@stablelib/hash";
 import type { KeyPair } from "@stablelib/x25519";
 import { sharedKey as deriveSharedKey } from "@stablelib/x25519";
-export { X25519Session } from "./keyagreement";
+export { X25519Session } from "./keyagreement.js";
 
 const SESSION_KEY_LENGTH = 32;
 

--- a/packages/x25519/keyagreement.ts
+++ b/packages/x25519/keyagreement.ts
@@ -5,7 +5,7 @@ import type { KeyAgreement } from "@stablelib/keyagreement";
 import type { RandomSource } from "@stablelib/random";
 import { randomBytes } from "@stablelib/random";
 import { wipe } from "@stablelib/wipe";
-import { PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, SHARED_KEY_LENGTH, generateKeyPairFromSeed, sharedKey } from "./x25519";
+import { PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, SHARED_KEY_LENGTH, generateKeyPairFromSeed, sharedKey } from "./x25519.js";
 
 /** Constants for key agreement */
 export const OFFER_MESSAGE_LENGTH = PUBLIC_KEY_LENGTH;


### PR DESCRIPTION
This pull request adds the `.js` extension and explicit `index.js` references to all relative imports to comply with the ES module specification and not rely on Node module loader specifics.

Should close https://github.com/StableLib/stablelib/issues/75